### PR TITLE
Visibility PR: Retain formatting CLI example Edge-Case.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 multiline strings are a pain in javascript.
 
-the most readable multiline string is as follows: 
+the most readable multiline string is as follows:
 
 #### Expected Result:
 ```javascript
 "
-this 
-is 
+this
+is
 a
 multiline
 string
@@ -27,7 +27,7 @@ def multilineStringExample() {
     'string' +
     '';
 
-  return stringConcatenation;  
+  return stringConcatenation;
 }
 ```
 
@@ -35,9 +35,9 @@ def multilineStringExample() {
 
 ```javascript
 def multilineStringExample() {
-  const taggedTemplate = mtrim ` 
-    this 
-    is 
+  const taggedTemplate = mtrim `
+    this
+    is
     a
     multiline
     string
@@ -52,7 +52,7 @@ def multilineStringExample() {
 $ npm install --save trim-multiline-string
 ```
 
-## FullUsage, (Use the library as a Function, Tagged Template, Prototype Function)
+## FullUsage, (Use the library as a Function, Tagged Template, Prototype Function), If Indent present keep Indent.!
 
 ```js
 const { mtrim } = require('trim-multiline-string');
@@ -61,15 +61,21 @@ console.log(
   mtrim(str),
 
   mtrim(`str`),
-  
+
   mtrim`
     check it out!
   `,
-  
+
   mtrim
     `check it out!`,
-  
+
   `str`.mtrim()
+
+  `
+   Keep Indent
+   Implementation
+   By Passing Number!
+  `.mtrim(3)
 )
 
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ string
 #### Before:
 
 ```javascript
-def multilineStringExample() {
+const multilineStringExample = () => {
   const  stringConcatenation  = '' +
     'this ' +
     'is' +
@@ -34,7 +34,7 @@ def multilineStringExample() {
 #### After:
 
 ```javascript
-def multilineStringExample() {
+const multilineStringExample = () => {
   const taggedTemplate = mtrim `
     this
     is

--- a/index.js
+++ b/index.js
@@ -1,10 +1,23 @@
+const numSpaces = (lines) =>
+  lines.reduce((acc, cur) => {
+    const  index = cur.search(/[^\s]/)
+    return ( index > 0 && ( acc == 0  || index < acc ) ) ? index : acc
+  }, 0)
+
+
 function mTrim ( str ) { // parameter is for the exporting mtrim function.
+  // console.log(str)
   if ( Array.isArray(str) ) { str = str[0] } // for tagged template implementation.
   if ( ! str ) { str = this; } // for prototype implementation.
   if ( str ) {
-    return str.split( '\n' ).map(x => x.trim()).join('\n')
+
+    const lines = str.split( '\n' )
+    const delSpacesNum = numSpaces(lines)
+
+    return lines.map(x => x.substring(delSpacesNum)).join('\n')
   }
 }
+
 String.prototype.mtrim = mTrim;
 module.exports = String;
 module.exports = { mtrim: mTrim };

--- a/index.js
+++ b/index.js
@@ -5,13 +5,15 @@ const numSpaces = (lines) =>
   }, 0)
 
 
-function mTrim ( str ) { // parameter is for the exporting mtrim function.
+function mTrim ( str, startingPad=0 ) { // parameter is for the exporting mtrim function.
   if ( Array.isArray(str) ) { str = str[0] } // for tagged template implementation.
+  if ( typeof str === "number" && this ) { startingPad = str; str = this; }
   if ( ! str ) { str = this; } // for prototype implementation.
+
   if ( str ) {
 
     const lines = str.split( '\n' )
-    const delSpacesNum = numSpaces(lines)
+    const delSpacesNum = numSpaces(lines) - startingPad
 
     return lines.map( (x, index) => (x.search(/[^\s]/) == -1) ? '' : (index > 0) ? x.substring(delSpacesNum) : x ).join('\n')
   }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const numSpaces = (lines) =>
 
 
 function mTrim ( str ) { // parameter is for the exporting mtrim function.
-  // console.log(str)
   if ( Array.isArray(str) ) { str = str[0] } // for tagged template implementation.
   if ( ! str ) { str = this; } // for prototype implementation.
   if ( str ) {
@@ -14,12 +13,10 @@ function mTrim ( str ) { // parameter is for the exporting mtrim function.
     const lines = str.split( '\n' )
     const delSpacesNum = numSpaces(lines)
 
-    return lines.map(x => x.substring(delSpacesNum)).join('\n')
+    return lines.map( (x, index) => (x.search(/[^\s]/) == -1) ? '' : (index > 0) ? x.substring(delSpacesNum) : x ).join('\n')
   }
 }
 
 String.prototype.mtrim = mTrim;
 module.exports = String;
 module.exports = { mtrim: mTrim };
-
-

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const numSpaces = (lines) =>
   lines.reduce((acc, cur) => {
-    const  index = cur.search(/[^\s]/)
-    return ( index > 0 && ( acc == 0  || index < acc ) ) ? index : acc
+    const indexOfFirstCharacter = cur.search(/[^\s]/)
+    return ( indexOfFirstCharacter >= 0 && ( acc == 0  || indexOfFirstCharacter < acc ) ) ? indexOfFirstCharacter : acc
   }, 0)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-trim-multiline-string",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "easy multiline syntax for javascript",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-trim-multiline-string",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "easy multiline syntax for javascript",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-trim-multiline-string",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "easy multiline syntax for javascript",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Example: (The updated code outputs this format correctly.)
```diff
REST Easy is a command line utility, which takes a JSON formatted configuration
file and performs REST GET requests against the defined target endpoints. 

Using this app, with JSON formatted config file, one can run n number of GET requests to the
defined target endpoints and display the response to the terminal (default).

Usage:
  rest_easy [command]

Available Commands:
  adhoc       Use the 'adhoc' sub-command to run GET requests against single 
endpoint
  help        Help about any command
  list        Use the 'list' sub-command to list the defined endpoints to be tested
  test        Use the 'test' sub-command to run GET requests to defined endpoints

Flags:
  -h, --help         help for rest_easy
      --log string   log file (default is ./rest_easy.log)
```

## Previous implementation was removing indents<br/>(Here is actual diff to the output effected by this commit):
```diff
- -h, --help         help for rest_easy
- adhoc       Use the 'adhoc' sub-command to run GET requests against single endpoint
- help        Help about any command
- list        Use the 'list' sub-command to list the defined endpoints to be tested
- test        Use the 'test' sub-command to run GET requests to defined endpoints
- --log string   log file (default is ./rest_easy.log)
+   -h, --help         help for rest_easy
+   adhoc       Use the 'adhoc' sub-command to run GET requests against single 
+   help        Help about any command
+   list        Use the 'list' sub-command to list the defined endpoints to be tested
+   test        Use the 'test' sub-command to run GET requests to defined endpoints
+       --log string   log file (default is ./rest_easy.log)
```